### PR TITLE
delete copy=False from data=inst.get_data, since it causes an error.

### DIFF
--- a/ieeg/timefreq/utils.py
+++ b/ieeg/timefreq/utils.py
@@ -149,7 +149,7 @@ def wavelet_scaleogram(inst: BaseEpochs, f_low: float = 2,
     <EpochsTFR | time : [-1.000000, 2.000000], freq : [2.079716, 1064.814640...
 
     """
-    data = inst.get_data(copy=False)
+    data = inst.get_data() #delete copy=False
 
     f = np.fft.fft(data - np.mean(data, axis=-1, keepdims=True))
 


### PR DESCRIPTION
`    data = inst.get_data() #delete copy=False parameter'

Change this line in wavelet_scaleogram because if I leave it as data = inst.get_data(copy=False), I get an error, saying that Epochs objects don't have the copy parameter.